### PR TITLE
feat: ✨ Added Font-Family Field to Summit Settings Doctype

### DIFF
--- a/summitapp/summitapp/doctype/summit_settings/summit_settings.json
+++ b/summitapp/summitapp/doctype/summit_settings/summit_settings.json
@@ -8,6 +8,7 @@
   "enable_user_based_menu",
   "variant_type",
   "header_component",
+  "font_family",
   "column_break_px7d",
   "show_variant_on_product_card",
   "variant_attribute_on_product_card",
@@ -55,12 +56,18 @@
    "fieldtype": "Link",
    "label": "Footer Component",
    "options": "Component"
+  },
+  {
+   "fieldname": "font_family",
+   "fieldtype": "Select",
+   "label": "Font Family",
+   "options": "\nBelgrano\nBelleza\nCairo\nCatamaran\nNunito\nPlayfair Display\nPoppins\nRoboto\nSofia\nSpectral"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-15 11:29:24.879125",
+ "modified": "2025-01-16 12:31:57.784638",
  "modified_by": "Administrator",
  "module": "SummitApp",
  "name": "Summit Settings",


### PR DESCRIPTION
# Description

This PR introduces a new field for font-family selection in the Summit settings doctype. The field allows users to configure and apply a specific font-family to their Summit platform for a more customized appearance.

## Changes Introduced

New Field:

Field Name: font_family
Field Type: Select
Field Label: Font Family
Options:
`Poppins
Nunito
Playfair Display
Roboto
Belgrano
Belleza
Catamaran
Cairo
Sofia
Spectral`

![image](https://github.com/user-attachments/assets/47cd61ef-a5d0-480c-81d0-9c7b7c0ed9bc)
