### PR TITLE
fix: Clear Colour field item Doctype

### DIFF
--- a/summitapp/overrides/item.py
+++ b/summitapp/overrides/item.py
@@ -58,7 +58,7 @@ def set_custom_attributes(doc):
                 elif variant.attribute == "Stone":
                     stone = value_row.abbr
 
-    doc.colour = colour
+    doc.custom_colour = colour
     doc.custom_size = size
     doc.custom_stone = stone
 


### PR DESCRIPTION
Issue ID: https://projects.8848digital.com/app/issue/03739
Subject: Can not select colour in item

**Description:**
To fix this issue having two field same label color but functionality is differ each other 
- color field
-- color field use to data entry field 
- custom_color
-- custom_color is auto set by item_attribute